### PR TITLE
Load avatars with Glide

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -54,6 +54,7 @@ dependencies {
     implementation libs.androidx.navigation.ui.ktx
     implementation(libs.gson)
     implementation(libs.okhttp)
+    implementation(libs.glide)
 
 
 }

--- a/app/src/main/java/ru/netology/myapp/adapter/PostAdapter.kt
+++ b/app/src/main/java/ru/netology/myapp/adapter/PostAdapter.kt
@@ -9,12 +9,13 @@ import androidx.appcompat.widget.PopupMenu
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.Glide
 import ru.netology.myapp.R
 import ru.netology.myapp.SingleCountFix
 import ru.netology.myapp.databinding.CardPostBinding
 import ru.netology.myapp.dto.Post
-import androidx.core.net.toUri
 import ru.netology.myapp.adapter.PostViewHolder.PostDiffCallBack
+import ru.netology.myapp.repository.PostRepositoryNetwork
 
 typealias onLikeListener = (post: Post) -> Unit
 typealias onRepostListener = (post: Post) -> Unit
@@ -62,6 +63,14 @@ class PostViewHolder(
         authorNameText.text = post.author
         postsContent.text = post.content
         publishedTimeText.text = post.published
+
+        val avatarUrl = post.authorAvatar?.let { "${PostRepositoryNetwork.BASE_URL}avatars/$it" }
+        Glide.with(postsAvatar)
+            .load(avatarUrl)
+            .placeholder(R.drawable.ic_netology)
+            .error(R.drawable.ic_netology)
+            .circleCrop()
+            .into(postsAvatar)
 
 //            like button codee
         likeButton.apply {

--- a/app/src/main/java/ru/netology/myapp/dto/Post.kt
+++ b/app/src/main/java/ru/netology/myapp/dto/Post.kt
@@ -8,6 +8,7 @@ data class Post(
     val published: String,
     val content: String,
     val video: String? = null,
+    val authorAvatar: String? = null,
 
 
     @SerializedName("likes")

--- a/app/src/main/java/ru/netology/myapp/repository/PostRepositoryNetwork.kt
+++ b/app/src/main/java/ru/netology/myapp/repository/PostRepositoryNetwork.kt
@@ -19,7 +19,7 @@ class PostRepositoryNetwork : PostRepository {
     private val listType = TypeToken.getParameterized(List::class.java, Post::class.java).type
 
     companion object {
-        private const val BASE_URL = "http://10.0.2.2:9999/"
+        const val BASE_URL = "http://10.0.2.2:9999/"
         private val jsonType = "application/json".toMediaType()
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ okhttp = "5.3.0"
 recyclerview = "1.4.0"
 gson = "2.11.0"
 nav = "2.9.6"
+glide = "4.16.0"
 
 [libraries]
 androidx-activity-ktx = { module = "androidx.activity:activity-ktx", version.ref = "activity" }
@@ -33,6 +34,7 @@ gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 androidx-navigation-fragment-ktx = { group = "androidx.navigation", name = "navigation-fragment-ktx", version.ref = "nav" }
 androidx-navigation-ui-ktx = { group = "androidx.navigation", name = "navigation-ui-ktx", version.ref = "nav" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
+glide = { module = "com.github.bumptech.glide:glide", version.ref = "glide" }
 
 
 


### PR DESCRIPTION
## Summary
- add Glide dependency and version catalog entry
- load author avatars from the server with circle cropping and fallbacks
- expose base URL constant for reuse when building avatar links

## Testing
- sh gradlew test *(fails: proxy 403 while downloading Gradle distribution)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942758abcb8832ab3363b399f0dea6b)